### PR TITLE
Fix numbering in menu.txt for en and it

### DIFF
--- a/english/menu.txt
+++ b/english/menu.txt
@@ -16,8 +16,8 @@
 8|Frequently Asked Questions|faq
 9|
 10|Development
-	9.1|API|api
-	9.2|Debugging|debugging
+	10.1|API|api
+	10.2|Debugging|debugging
 11|
 12|Sitemap|sitemap
 13|

--- a/italian/menu.txt
+++ b/italian/menu.txt
@@ -16,8 +16,8 @@
 8|Domande frequenti|faq
 9|
 10|Sviluppo
-	9.1|API|api
-	9.2|Debugging|debugging
+	10.1|API|api
+	10.2|Debugging|debugging
 11|
 12|Sitemap|sitemap
 13|


### PR DESCRIPTION
Although this doesn't seem to have an effect on the menu, it still works with the incorrect numbering...
